### PR TITLE
Fix root & /docs redirect not working

### DIFF
--- a/config/legacy.oas.json
+++ b/config/legacy.oas.json
@@ -5,6 +5,29 @@
       "title": "Dev Portal Redirect"
     },
     "paths": {
+      "/": {
+        "x-zuplo-path": {
+          "pathMode": "url-pattern"
+        },
+        "get": {
+          "summary": "Root Redirect",
+          "description": "Redirect root to the Dev Portal",
+          "x-zuplo-route": {
+            "corsPolicy": "none",
+            "handler": {
+              "export": "legacyDevPortalHandler",
+              "module": "$import(@zuplo/runtime)",
+              "options": {
+                "mode": "redirect"
+              }
+            },
+            "policies": {
+              "inbound": []
+            }
+          },
+          "operationId": "root-redirect"
+        }
+      },
       "/docs(.*)": {
         "x-zuplo-path": {
           "pathMode": "url-pattern"

--- a/config/routes.oas.json
+++ b/config/routes.oas.json
@@ -469,31 +469,6 @@
         }
       }
     },
-    "/": {
-      "x-zuplo-path": {
-        "pathMode": "url-pattern"
-      },
-      "get": {
-        "x-internal": true,
-        "summary": "Root redirect",
-        "operationId": "c3cd546b-c521-4700-bd37-1622c57158c0",
-        "x-zuplo-route": {
-          "corsPolicy": "none",
-          "policies": {
-            "inbound": [],
-            "outbound": []
-          },
-          "handler": {
-            "export": "redirectHandler",
-            "module": "$import(@zuplo/runtime)",
-            "options": {
-              "location": "/docs",
-              "status": 301
-            }
-          }
-        }
-      }
-    },
     "/openapi.json": {
       "x-zuplo-path": {
         "pathMode": "open-api"


### PR DESCRIPTION
The new Zudoku dev portal runs on its own dedicated domain -- it's no longer served at /docs on the API domain. The old root route was using redirectHandler to send users to /docs, but nothing is hosted there anymore.

We now use legacyDevPortalHandler (same handler already used for /docs(.*) redirects), which knows the dev portal's actual domain and will redirect users there directly in a single hop.