### PR TITLE
Serve Zudoku from root, drop /docs basePath

### DIFF
--- a/config/routes.oas.json
+++ b/config/routes.oas.json
@@ -125,6 +125,7 @@
           {
             "name": "characterId",
             "in": "path",
+            "required": true,
             "description": "A single numeric ID or multiple IDs, e.g. `[1,2,3]` or `1,2`",
             "schema": {
               "type": "string",
@@ -263,6 +264,7 @@
           {
             "name": "locationId",
             "in": "path",
+            "required": true,
             "description": "A single numeric ID or multiple IDs, e.g. `[1,2,3]` or `1,2`",
             "schema": {
               "type": "string"
@@ -382,6 +384,7 @@
           {
             "name": "episodeId",
             "in": "path",
+            "required": true,
             "description": "A single numeric ID or multiple IDs, e.g. `[1,2,3]` or `1,2`",
             "schema": {
               "type": "string"
@@ -446,56 +449,6 @@
             "module": "$import(@zuplo/runtime)",
             "options": {
               "rewritePattern": "https://rickandmortyapi.com/api/character/avatar/${params.imageId}"
-            }
-          }
-        }
-      }
-    },
-    "/favicon.ico": {
-      "x-zuplo-path": {
-        "pathMode": "url-pattern"
-      },
-      "get": {
-        "x-internal": true,
-        "summary": "Favicon",
-        "description": "Lorem ipsum dolor sit amet, **consectetur adipiscing** elit, sed do `eiusmod tempor` incididunt ut labore et dolore magna aliqua.",
-        "operationId": "d76634dd-bd55-4897-b500-44e6d700be30",
-        "x-zuplo-route": {
-          "corsPolicy": "none",
-          "policies": {
-            "inbound": [],
-            "outbound": []
-          },
-          "handler": {
-            "export": "urlRewriteHandler",
-            "module": "$import(@zuplo/runtime)",
-            "options": {
-              "rewritePattern": "https://rickandmortyapi.com/favicon-32x32.png"
-            }
-          }
-        }
-      }
-    },
-    "/": {
-      "x-zuplo-path": {
-        "pathMode": "url-pattern"
-      },
-      "get": {
-        "x-internal": true,
-        "summary": "Root redirect",
-        "operationId": "c3cd546b-c521-4700-bd37-1622c57158c0",
-        "x-zuplo-route": {
-          "corsPolicy": "none",
-          "policies": {
-            "inbound": [],
-            "outbound": []
-          },
-          "handler": {
-            "export": "redirectHandler",
-            "module": "$import(@zuplo/runtime)",
-            "options": {
-              "location": "/docs",
-              "status": 301
             }
           }
         }

--- a/docs/pages/characters.mdx
+++ b/docs/pages/characters.mdx
@@ -103,6 +103,6 @@ Here are some fan favorites to get you started:
 
 ## Next steps
 
-- [Locations Guide](/docs/locations) — where do these characters live?
-- [Episodes Guide](/docs/episodes) — which episodes do they appear in?
-- [API Reference](/docs/api) — try the Characters endpoints interactively
+- [Locations Guide](/locations) — where do these characters live?
+- [Episodes Guide](/episodes) — which episodes do they appear in?
+- [API Reference](/api) — try the Characters endpoints interactively

--- a/docs/pages/episodes.mdx
+++ b/docs/pages/episodes.mdx
@@ -113,6 +113,6 @@ Each episode includes a `characters` array with URLs to every character that app
 
 ## Next steps
 
-- [Characters Guide](/docs/characters) — look up the characters from any episode
-- [Locations Guide](/docs/locations) — explore where episodes take place
-- [API Reference](/docs/api) — try the Episodes endpoints interactively
+- [Characters Guide](/characters) — look up the characters from any episode
+- [Locations Guide](/locations) — explore where episodes take place
+- [API Reference](/api) — try the Episodes endpoints interactively

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -91,7 +91,7 @@ Use the `page` query parameter to navigate: `?page=2`, `?page=3`, etc.
 
 ## Next steps
 
-- [Characters Guide](/docs/characters) — explore character data and filtering
-- [Locations Guide](/docs/locations) — browse the multiverse
-- [Episodes Guide](/docs/episodes) — find episodes and their casts
-- [API Reference](/docs/api) — full interactive API documentation
+- [Characters Guide](/characters) — explore character data and filtering
+- [Locations Guide](/locations) — browse the multiverse
+- [Episodes Guide](/episodes) — find episodes and their casts
+- [API Reference](/api) — full interactive API documentation

--- a/docs/pages/locations.mdx
+++ b/docs/pages/locations.mdx
@@ -98,6 +98,6 @@ The `residents` array in each location response contains URLs to the characters 
 
 ## Next steps
 
-- [Characters Guide](/docs/characters) — explore the residents of these locations
-- [Episodes Guide](/docs/episodes) — find episodes set in specific locations
-- [API Reference](/docs/api) — try the Locations endpoints interactively
+- [Characters Guide](/characters) — explore the residents of these locations
+- [Episodes Guide](/episodes) — find episodes set in specific locations
+- [API Reference](/api) — try the Locations endpoints interactively

--- a/docs/pages/welcome.mdx
+++ b/docs/pages/welcome.mdx
@@ -7,7 +7,7 @@ description: REST API for Rick and Morty characters, locations, and episodes —
 Welcome to the **Rick and Morty API** documentation. This RESTful API gives you access to hundreds of characters, locations, and episodes from the Rick and Morty universe. Built on [Zuplo](https://zuplo.com), it features API key authentication, rate limiting, and full OpenAPI documentation.
 
 <Callout type="tip">
-New here? Head to the [Getting Started](/docs/getting-started) guide to get your API key and make your first request in under 2 minutes.
+New here? Head to the [Getting Started](/getting-started) guide to get your API key and make your first request in under 2 minutes.
 </Callout>
 
 ## What's in the multiverse?
@@ -16,19 +16,19 @@ New here? Head to the [Getting Started](/docs/getting-started) guide to get your
 
 Access data on **826+ characters** — from Rick Sanchez and Morty Smith to Pickle Rick and Abradolf Lincler. Filter by name, status, species, gender, and more.
 
-[Explore Characters →](/docs/characters)
+[Explore Characters →](/characters)
 
 ### 🌍 Locations & Dimensions
 
 Browse locations across the multiverse: Earth (Dimension C-137), the Citadel of Ricks, Anatomy Park, Blips and Chitz, and beyond. Every location includes its dimension and resident characters.
 
-[Explore Locations →](/docs/locations)
+[Explore Locations →](/locations)
 
 ### 📺 Episodes
 
 All episodes from every season, with air dates, episode codes, and the characters that appear in each one.
 
-[Explore Episodes →](/docs/episodes)
+[Explore Episodes →](/episodes)
 
 ## Quick example
 
@@ -54,5 +54,5 @@ curl -H "Authorization: Bearer YOUR_API_KEY" \
 
 ## Ready to get schwifty?
 
-- [Getting Started](/docs/getting-started) — sign up and make your first request
-- [API Reference](/docs/api) — full interactive reference with try-it-out
+- [Getting Started](/getting-started) — sign up and make your first request
+- [API Reference](/api) — full interactive reference with try-it-out

--- a/docs/src/PickleExplosion.tsx
+++ b/docs/src/PickleExplosion.tsx
@@ -13,7 +13,7 @@ export default function PickleExplosion({ location }: ExposedComponentProps) {
   const nextId = useRef(0);
 
   // Disable on API reference pages
-  const isApiPage = location.pathname.startsWith("/api") || location.pathname.startsWith("/docs/api");
+  const isApiPage = location.pathname.startsWith("/api");
 
   useEffect(() => {
     if (isApiPage) return;
@@ -125,7 +125,7 @@ function PickleBurst({ x, y }: { x: number; y: number }) {
             } as React.CSSProperties
           }
         >
-          <img src="/docs/pickle-rick.png" alt="Pickle Rick" style={{ width: "1em", height: "auto" }} />
+          <img src="/pickle-rick.png" alt="Pickle Rick" style={{ width: "1em", height: "auto" }} />
         </span>
       ))}
     </>

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -4,7 +4,7 @@ import LandingPage from "./src/LandingPage.js";
 import PickleExplosion from "./src/PickleExplosion.js";
 
 const config: ZudokuConfig = {
-  basePath: "/docs",
+  basePath: "/",
   docs: {
     files: "pages/**/*.{md,mdx}",
     publishMarkdown: true,
@@ -161,6 +161,9 @@ const config: ZudokuConfig = {
     clientId: "v0cOpST3pX6NIs1VGLVvNjaN3mSBomKk",
     domain: "zuplo-samples.us.auth0.com",
     audience: "https://api.example.com/",
+  },
+  apiKeys: {
+    enabled: true,
   },
   plugins: [
     zuploMonetizationPlugin({

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
       "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
       "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@base-ui/utils": "0.2.8",
@@ -109,6 +110,7 @@
       "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@floating-ui/utils": "^0.2.11",
@@ -687,6 +689,22 @@
       "optional": true,
       "os": [
         "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
       ],
       "engines": {
         "node": ">=18"
@@ -3192,6 +3210,7 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
       "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -3207,7 +3226,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pagefind/darwin-x64": {
       "version": "1.5.2",
@@ -3220,7 +3240,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pagefind/freebsd-x64": {
       "version": "1.5.2",
@@ -3233,7 +3254,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pagefind/linux-arm64": {
       "version": "1.5.2",
@@ -3246,7 +3268,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pagefind/linux-x64": {
       "version": "1.5.2",
@@ -3259,7 +3282,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pagefind/windows-arm64": {
       "version": "1.5.2",
@@ -3272,7 +3296,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pagefind/windows-x64": {
       "version": "1.5.2",
@@ -3285,7 +3310,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
@@ -4983,6 +5009,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4999,6 +5026,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5015,6 +5043,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5031,6 +5060,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5047,6 +5077,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5066,6 +5097,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5085,6 +5117,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5104,6 +5137,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5123,6 +5157,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5142,6 +5177,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5161,6 +5197,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5177,6 +5214,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5190,6 +5228,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -5211,6 +5250,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5227,6 +5267,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -5235,7 +5276,8 @@
       "version": "1.0.0-rc.7",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -5288,8 +5330,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -5302,8 +5343,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -5316,8 +5356,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -5330,8 +5369,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -5344,8 +5382,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -5358,8 +5395,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -5372,8 +5408,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -5386,8 +5421,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -5400,8 +5434,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -5414,8 +5447,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -5428,8 +5460,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -5442,8 +5473,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -5456,8 +5486,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -5470,8 +5499,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -5484,8 +5512,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -5498,8 +5525,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -5512,8 +5538,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -5526,8 +5551,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -5540,8 +5564,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -5554,8 +5577,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -5568,8 +5590,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -5582,8 +5603,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -5596,8 +5616,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -5610,8 +5629,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -5624,8 +5642,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@scalar/helpers": {
       "version": "0.2.7",
@@ -6248,6 +6265,7 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
       "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "enhanced-resolve": "^5.19.0",
@@ -6262,13 +6280,15 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
       "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20"
       },
@@ -6299,6 +6319,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6315,6 +6336,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6331,6 +6353,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6347,6 +6370,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6363,6 +6387,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6382,6 +6407,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6401,6 +6427,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6420,6 +6447,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6439,6 +6467,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6460,6 +6489,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.8.1",
         "@emnapi/runtime": "^1.8.1",
@@ -6484,6 +6514,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -6500,6 +6531,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -10181,6 +10213,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10802,6 +10835,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -10838,6 +10872,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10858,6 +10893,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10878,6 +10914,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10898,6 +10935,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10918,6 +10956,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10941,6 +10980,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10964,6 +11004,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10987,6 +11028,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -11010,6 +11052,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -11030,6 +11073,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -11050,6 +11094,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12833,6 +12878,7 @@
       "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
       "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "pagefind": "lib/runner/bin.cjs"
       },
@@ -13579,7 +13625,8 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -14146,7 +14193,8 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -14371,6 +14419,7 @@
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
         "@rolldown/pluginutils": "1.0.0-rc.15"
@@ -14403,14 +14452,14 @@
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -15529,6 +15578,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -15928,6 +15978,7 @@
       "version": "0.76.0",
       "resolved": "https://registry.npmjs.org/zudoku/-/zudoku-0.76.0.tgz",
       "integrity": "sha512-8OdEQ7153hmBmszbKJGyPmr2vapZ7nvGsFmC/YDpkUU6rYghJBVWkV0DRWPGhHLAM3820QxtrILnBxLyVP/eNw==",
+      "peer": true,
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "15.3.1",
         "@base-ui/react": "^1.4.0",
@@ -16090,6 +16141,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16106,6 +16158,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16122,6 +16175,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16138,6 +16192,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16154,6 +16209,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16170,6 +16226,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16186,6 +16243,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16202,6 +16260,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16218,6 +16277,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16234,6 +16294,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16250,6 +16311,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16266,6 +16328,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16282,6 +16345,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16298,6 +16362,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16314,6 +16379,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16330,6 +16396,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16346,6 +16413,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16362,6 +16430,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16378,6 +16447,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16394,6 +16464,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16410,22 +16481,7 @@
       "os": [
         "openbsd"
       ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/zudoku/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16442,6 +16498,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16458,6 +16515,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16474,6 +16532,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16490,6 +16549,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16499,6 +16559,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -16516,6 +16577,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.211.0.tgz",
       "integrity": "sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -16528,6 +16590,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
       "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -16540,6 +16603,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -16555,6 +16619,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
       "integrity": "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.211.0",
         "import-in-the-middle": "^2.0.0",
@@ -16572,6 +16637,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.58.0.tgz",
       "integrity": "sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16589,6 +16655,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.54.0.tgz",
       "integrity": "sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16607,6 +16674,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.28.0.tgz",
       "integrity": "sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
       },
@@ -16622,6 +16690,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.59.0.tgz",
       "integrity": "sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16639,6 +16708,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.30.0.tgz",
       "integrity": "sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0"
@@ -16655,6 +16725,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.54.0.tgz",
       "integrity": "sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
       },
@@ -16670,6 +16741,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.58.0.tgz",
       "integrity": "sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
       },
@@ -16685,6 +16757,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.57.0.tgz",
       "integrity": "sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16702,6 +16775,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.211.0.tgz",
       "integrity": "sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/instrumentation": "0.211.0",
@@ -16720,6 +16794,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
       "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -16735,6 +16810,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.59.0.tgz",
       "integrity": "sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
         "@opentelemetry/redis-common": "^0.38.2",
@@ -16752,6 +16828,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.20.0.tgz",
       "integrity": "sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
         "@opentelemetry/semantic-conventions": "^1.30.0"
@@ -16768,6 +16845,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.55.0.tgz",
       "integrity": "sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
         "@opentelemetry/semantic-conventions": "^1.33.1"
@@ -16784,6 +16862,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.59.0.tgz",
       "integrity": "sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16801,6 +16880,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.55.0.tgz",
       "integrity": "sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
       },
@@ -16816,6 +16896,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.64.0.tgz",
       "integrity": "sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
@@ -16832,6 +16913,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.57.0.tgz",
       "integrity": "sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16849,6 +16931,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.57.0.tgz",
       "integrity": "sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
@@ -16866,6 +16949,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.57.0.tgz",
       "integrity": "sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
@@ -16883,6 +16967,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.63.0.tgz",
       "integrity": "sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16903,6 +16988,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.30.0.tgz",
       "integrity": "sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
@@ -16920,6 +17006,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.21.0.tgz",
       "integrity": "sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -16937,6 +17024,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
       "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       }
@@ -16946,6 +17034,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
       "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -16962,6 +17051,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
       "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/resources": "2.6.0",
@@ -16979,6 +17069,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
       "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "^2.0.0"
       },
@@ -16994,6 +17085,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.2.0.tgz",
       "integrity": "sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.207.0"
       },
@@ -17006,6 +17098,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
       "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -17018,6 +17111,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
       "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.207.0",
         "import-in-the-middle": "^2.0.0",
@@ -17035,6 +17129,7 @@
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.42.0.tgz",
       "integrity": "sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17044,6 +17139,7 @@
       "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.42.0.tgz",
       "integrity": "sha512-ZZfU3Fnni7Aj0lTX4e3QpY3UxK4FGuzfM20316UAJycBGnripm+sDHwcekPMGfLnk/FrN9wa1atspVlHvOI0WQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/otel": "0.16.0",
         "@opentelemetry/api": "^1.9.0",
@@ -17090,6 +17186,7 @@
       "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.42.0.tgz",
       "integrity": "sha512-5vsYz683iihzlIj3sT1+tEixf0awwXK86a+aYsnMHrTXJDrkBDq4U0ZT+yxdPfJlkaxRtYycFR08SXr2pSm7Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sentry/core": "10.42.0"
       },
@@ -17109,6 +17206,7 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
       "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tailwindcss/node": "4.2.2",
         "@tailwindcss/oxide": "4.2.2",
@@ -17122,13 +17220,15 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zudoku/node_modules/@types/mysql": {
       "version": "2.15.27",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
       "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -17138,6 +17238,7 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
       "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -17149,6 +17250,7 @@
       "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
       "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/pg": "*"
       }
@@ -17158,6 +17260,7 @@
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
       "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rolldown/pluginutils": "1.0.0-rc.7"
       },
@@ -17183,6 +17286,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17195,6 +17299,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -17204,6 +17309,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
       "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -17215,13 +17321,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zudoku/node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^7.2.0",
         "strip-ansi": "^7.1.0",
@@ -17236,6 +17344,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
       "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17247,7 +17356,8 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zudoku/node_modules/esbuild": {
       "version": "0.27.7",
@@ -17255,6 +17365,7 @@
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -17295,6 +17406,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -17312,6 +17424,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -17324,6 +17437,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
@@ -17339,6 +17453,7 @@
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
       "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-import-attributes": "^1.9.5",
@@ -17351,6 +17466,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -17360,6 +17476,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -17376,6 +17493,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17388,6 +17506,7 @@
       "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.26.0.tgz",
       "integrity": "sha512-DK1XF/RiunhvT57cFyPxW9OaliZzl5aREHFwY/AISL3MVOaDUb4wIccMn0G3ws3Ounen8iGH7xvzZQ0x2vEOEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@posthog/core": "1.23.1"
       },
@@ -17400,6 +17519,7 @@
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
       "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.5",
         "module-details-from-path": "^1.0.3"
@@ -17413,6 +17533,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -17425,6 +17546,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -17442,6 +17564,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.2.2"
       },
@@ -17457,6 +17580,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17534,6 +17658,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -17551,6 +17676,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
@@ -17568,6 +17694,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
@@ -17577,6 +17704,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- Zudoku is now served from `/` instead of `/docs` (matches the official `zuplo-monetization` example layout)
- Removed the `/` → `/docs` redirect and `/favicon.ico` passthrough from `routes.oas.json` — Zudoku handles both
- Added `required: true` to all path parameters (fixes OpenAPI schema warning seen in `zup dev`)
- Added `apiKeys: { enabled: true }` — required by Zudoku 0.76.0 to render the login UI when `authentication` is configured
- Updated all `/docs/*` internal links in MDX pages and `PickleExplosion.tsx` to root-relative paths

## Test plan
- [x] `npm run build` (in `docs/`) completes without errors; 26 routes prerendered
- [ ] Visit `/` — landing page renders, login button visible in header
- [ ] Navigate Documentation, API Reference, Pricing — all working from root
- [ ] Sign in flow works end-to-end
- [ ] Favicon is the Zuplo-branded asset from `metadata.favicon` (hard-refresh first to bust cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)